### PR TITLE
Use Slack's secondary message attachment for displaying logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # health-check
-A health check executable that checks for common server failure modes
+
+A health check executable that checks for common server failure modes.

--- a/examples/sleep-check.rs
+++ b/examples/sleep-check.rs
@@ -16,7 +16,9 @@ impl Cli {
     fn run(&self) {
         loop {
             if self.stdout_print {
-                println!("Printing to stdout");
+                for _ in 1..50 {
+                    println!("Printing to stdout");
+                }
             }
             eprintln!("Printing to stderr {}", self.output_timeout);
             std::thread::sleep(Duration::from_secs(self.output_timeout.into()));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,7 @@ pub(crate) struct Cli {
     #[arg(required = false)]
     pub(crate) args: Vec<String>,
     /// How many lines of output should we store for error messages?
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 50, env = "HEALTH_CHECK_OUTPUT_LINES")]
     pub(crate) output_lines: usize,
 }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -75,12 +75,15 @@ impl SlackApp {
                     },
                 },
                 {
-                    "type": "section",
-                    "text": {
-                        "type": "plain_text",
-                        "text": latest_output,
-                    }
-                },
+                    "type": "divider"
+                }
+            ],
+            "attachments": [
+                {
+                    "mrkdwn_in": ["text"],
+                    "author_name": "Logs",
+                    "text": latest_output
+                }
             ]
         });
         if let Some(image_url) = &self.app_info.image_url {


### PR DESCRIPTION
It is a part of a legacy slack feature, but I wasn't able to find equivalent API in their new API's.  This is how it will look:

![after_slack](https://github.com/fpco/health-check/assets/737477/2616a55a-f438-4bfb-a1bc-0a820df4f089)

I have also bumped the log lines to 50 (from 10).