### PR TITLE
Make slack_webhook as non optional parameter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,13 +54,6 @@ pub(crate) struct Cli {
     pub(crate) output_lines: usize,
 }
 
-#[derive(clap::Args)]
-#[group(required = true, multiple = false)]
-pub(crate) struct NotifyHook {
-    #[arg(long, value_parser(Url::from_str), env = "HEALTH_CHECK_SLACK_WEBHOOK")]
-    pub(crate) slack_webhook: Url,
-}
-
 #[derive(Debug)]
 enum MainMessage {
     Error(anyhow::Error),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,9 +25,9 @@ pub(crate) struct Cli {
     /// Seconds to wait for output before killing the task
     #[arg(long)]
     pub(crate) task_output_timeout: Option<u64>,
-    /// Notification hook
-    #[command(flatten)]
-    pub(crate) notification_hook: NotifyHook,
+    /// Slack Webhook for notification
+    #[arg(long, value_parser(Url::from_str), env = "HEALTH_CHECK_SLACK_WEBHOOK")]
+    pub(crate) slack_webhook: Url,
     /// Application description
     #[arg(long)]
     pub(crate) app_description: String,
@@ -192,7 +192,7 @@ impl Cli {
             Ok(()) => Ok(()),
             Err(e) => {
                 let slack_app = SlackApp::new(
-                    self.notification_hook.slack_webhook,
+                    self.slack_webhook,
                     self.notification_context,
                     self.app_description,
                     self.app_version,


### PR DESCRIPTION
Initially the CLI argument slack_webhook was optional, even though other options related to notification were required to be passed (Thanks to Kirill for raising this point to me):

- app name
- app version
- notification context

I made the slack_webhook optional to convey the fact that the notification system is pluggable and you could instead optionally integrate other providers like Discord or Microsoft teams. Making it as non optional would indicate that this tool is tied to slack.

I discovered that this problem is solved by clap's ArgGroup, so I have converted the solution to that. This also makes sure that we pass atleast one parameter of the NotifyHook struct.